### PR TITLE
Project now supports 100GB files

### DIFF
--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -4306,11 +4306,10 @@ module.exports = {
         receivedBuffers.push(remainder);
         receivedBuffersLength = remainder.length;
 
-        // Return the original buffer.
-        var bufCopy = new Buffer(partSizeThreshold);
-        var slice = combinedBuffer.slice(0, partSizeThreshold);
-        slice.copy(bufCopy);
-        return bufCopy;
+        // Return the perfectly sized part.
+        var uploadBuffer = new Buffer(partSizeThreshold);
+        combinedBuffer.copy(uploadBuffer, 0, 0, partSizeThreshold);
+        return uploadBuffer;
       }
       else {
         // It just happened to be perfectly sized, so return it.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 
   "dependencies": {
     "filereader-stream": "git://github.com/konklone/filereader-stream.git#backpressure",
-    "s3-upload-stream": "git://github.com/konklone/s3-upload-stream.git#buffer-memory"
+    "s3-upload-stream": "git://github.com/nathanpeck/s3-upload-stream.git#1.0.5"
   },
 
   "main": "index.js",


### PR DESCRIPTION
[![200gb](https://cloud.githubusercontent.com/assets/4592/4618717/daec1c2c-530c-11e4-9c8b-f6392bf37ae9.png)](https://twitter.com/konklone/status/521718929010745344)

https://twitter.com/konklone/status/521718929010745344

This brings in a patch, that I worked out in https://github.com/nathanpeck/s3-upload-stream/issues/20 with the author of s3-upload-stream, to fix an issue where browsers were not properly respecting sliced buffer windows. This was causing browsers to send in more data than the client was expecting, and so MD5 calculations were off, everything was off.

This was coming into effect at smaller sizes, but then vanished -- but reappeared when uploading ~20MB parts (of a 200GB file).

This brings the supported file size of this project from **10GB** to **100GB**!
## Next steps

Next steps are as documented in https://github.com/konklone/bit-voyage/pull/6:
- It will be tougher to get to 1TB+, because that makes the part size (100MB) unmanageable by the client. I gave it a brief shot with 200MB parts and my browser tab crashed on the first `xhr.send()`. As of right now, with S3's limitations I think this will require a server-side proxy. Even a weak server should be capable of making a sustained 100MB HTTP upload (or 500MB, to hit Amazon's max of 5TB) to S3. A server-side proxy could take data streamed however (e.g. Websockets), because multi-part chunking would have to take place entirely server-side.
- The Internet Archive would be a nice next goal, but they don't support CORS yet. I'll ask them to update this.
