### PR TITLE
Allow uploading of private files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ todo.txt
 scrap.js
 assets/js/aws-sdk-2.0.19.js
 npm-debug.log
+manifest.yml

--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
       <input type="text" class="param secret-key" placeholder="secret-key" />
     </p>
     <p>
+      <label for="public"><strong>Make files publicly downloadable:</strong></label>
+      <input type="checkbox" checked name="public" id="public" />
+    </p>
+    <p>
       <a class="linkify s3 test">Test your S3 details.</a>
       <span class="s3-test loading"><blink>Testing...</blink></span>
       <span class="s3-test success">Test succeeded! Drop a file any time.</span>

--- a/index.html
+++ b/index.html
@@ -64,13 +64,13 @@
   <section class="instructions">
     <p>
       <strong>CORS trouble?</strong>
-      Paste this into your S3 bucket's CORS configuration. Change <code class="inline">https://bit.voyage</code> to <code class="inline">*</code> to allow it to come from anywhere.
+      Paste this into your S3 bucket's CORS configuration.
     </p>
   <code><pre id="instructions">
 &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
 &lt;CORSConfiguration xmlns=&quot;http://s3.amazonaws.com/doc/2006-03-01/&quot;&gt;
     &lt;CORSRule&gt;
-        &lt;AllowedOrigin&gt;https://bit.voyage&lt;/AllowedOrigin&gt;
+        &lt;AllowedOrigin&gt;*&lt;/AllowedOrigin&gt;
         &lt;AllowedMethod&gt;HEAD&lt;/AllowedMethod&gt;
         &lt;AllowedMethod&gt;GET&lt;/AllowedMethod&gt;
         &lt;AllowedMethod&gt;PUT&lt;/AllowedMethod&gt;

--- a/index.js
+++ b/index.js
@@ -138,7 +138,8 @@ var params = qs.parse(location.hash ? location.hash.replace("#", "") : null);
 var session = {
   key: params.key,
   "secret-key": params['secret-key'],
-  bucket: params.bucket
+  bucket: params.bucket,
+  public: params.public // "true" or "false"
 };
 
 // active upload
@@ -174,6 +175,7 @@ var log = utils.log("main-log");
 $(".bucket").val(params.bucket);
 $(".access-key").val(params.key);
 $(".secret-key").val(params['secret-key']);
+$("#public").prop("checked", (params.public == "false" ? false : true));
 
 // changing values updates session automatically
 $(".param").keyup(function() {
@@ -182,6 +184,12 @@ $(".param").keyup(function() {
   session.key = $(".access-key").val();
   session["secret-key"] = $(".secret-key").val();
   initAWS();
+  utils.updateLink(qs, session);
+});
+
+$("#public").click(function() {
+  console.log("changed permissions, public: " + permissions());
+  session.public = permissions().toString();
   utils.updateLink(qs, session);
 });
 
@@ -300,7 +308,7 @@ var uploadFile = function(file) {
           data.Location +
         "</a>";
     } else {
-      download += file.name + " has been uploaded to private bucket as " +
+      download += file.name + " has been uploaded privately as " +
         " <strong>" + data.Key + "</strong>.";
     }
 

--- a/index.js
+++ b/index.js
@@ -205,12 +205,10 @@ $(".s3.test").click(function() {
 });
 
 /**
- * Initializing and updating the current upload.
- * Used by 'part' event handler for S3 stream.
+ * Has the user said the file can be publicly downloadable?
  */
-
-function updateUpload() {
-
+function permissions() {
+  return $("#public").prop("checked");
 };
 
 
@@ -262,8 +260,11 @@ var uploadFile = function(file) {
     "Bucket": params.bucket,
     "Key": file.name,
     "ContentType": file.type,
-    "ACL": "public-read"
+    "ACL": (permissions() ? "public-read" : "private")
   });
+
+  // for later fetching, even if the user checked/unchecked the box during the upload
+  upload.public = permissions();
 
   // by default, part size means a 50GB max (10000 part limit)
   // by raising part size, we increase total capacity
@@ -291,11 +292,19 @@ var uploadFile = function(file) {
   });
 
   upload.on('uploaded', function(data) {
-    log("Arrived! Download <strong>" + file.name + "</strong> at " +
-      "<a href=\"" + data.Location + "\">" +
-        data.Location +
-      "</a>"
-    );
+    var download = "Arrived! ";
+
+    if (upload.public) {
+      download += "Download <strong>" + file.name + "</strong> at " +
+        "<a target=\"_blank\" href=\"" + data.Location + "\">" +
+          data.Location +
+        "</a>";
+    } else {
+      download += file.name + " has been uploaded to private bucket as " +
+        " <strong>" + data.Key + "</strong>.";
+    }
+
+    log(download);
 
     $(".control").hide();
 


### PR DESCRIPTION
This PR does 4 things:
- https://github.com/konklone/bit.voyage/commit/8cc7fcebb6a08255dd55d5d9e29183cc0b989776 - Ignores any `manifest.yml` file that a Cloud Foundry app deployment model might use.
- https://github.com/konklone/bit.voyage/commit/3a4d3d8b136498831b2e6133494e954a0f5d0d4d - Default to a CORS policy of `*`, to avoid hardcoding in `https://bit.voyage` as the default CORS policy people paste into buckets.
- https://github.com/konklone/bit.voyage/commit/73e5664c1fb30cb7cb18408d28391c0b267cb352 - Allows people to turn on/off whether files should be publicly downloadable. Defaults to public, as before.
- https://github.com/konklone/bit.voyage/commit/aad6dd364499a2c8743d763321b5e1f3b2854a56 - Make the public/private bit "sticky" and automatically synced into the permalink. If someone configures a URL to give to someone else, it should automatically preserve the visibility setting.
